### PR TITLE
Copy almalinux-8 into manylinux_2_28

### DIFF
--- a/.github/workflows/create_manylinux_2_28_swigex0.yml
+++ b/.github/workflows/create_manylinux_2_28_swigex0.yml
@@ -1,0 +1,25 @@
+name: manylinux_2_28 for swigex0-based R software
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Manual'
+        required: false
+        default: ''
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and push manylinux_2_28-swigex0-r docker
+        working-directory: .
+        run: |
+          docker build -t ${{env.USER}}/manylinux_2_28-swigex0-r -f manylinux/2_28/Dockerfile_swigex0_r .
+          docker login -u ${{env.USER}} -p ${{env.TOKEN}}
+          docker push ${{env.USER}}/manylinux_2_28-swigex0-r
+          docker logout
+        env:
+          USER: ${{ secrets.DOCKER_HUB_USERNAME }}
+          TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/manylinux/2_28/Dockerfile_swigex0_r
+++ b/manylinux/2_28/Dockerfile_swigex0_r
@@ -1,0 +1,77 @@
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+# UPDATE repo
+RUN dnf -y update && dnf -y install epel-release && dnf clean all
+
+# INSTALL dependencies
+RUN dnf -y install \
+    sudo wget diffutils make gcc-c++ gettext unzip \
+    zlib-devel libffi-devel sqlite-devel openssl-devel \
+    gcc-gfortran bzip2-devel xz-devel \
+    fontconfig-devel libxml2-devel \
+    harfbuzz-devel fribidi-devel freetype-devel libpng-devel \
+    libjpeg-turbo-devel libtiff-devel libcurl-devel tzdata \
+    cairo-devel libXt-devel pcre2-devel \
+    python3 graphviz flex \
+    git cmake gzip xz which
+
+# INSTALL recent bison
+RUN dnf -y install m4 wget tar && \
+    wget http://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz && \
+    tar -xvzf bison-3.8.2.tar.gz && \
+    cd bison-3.8.2 && \
+    ./configure --prefix=/usr/local&& \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && \
+    rm -rf bison-3.8.2*
+
+# INSTALL Doxygen
+RUN git clone --branch Release_1_9_8 https://github.com/doxygen/doxygen.git && \
+    cd doxygen && \
+    mkdir build && cd build && \
+    cmake -G "Unix Makefiles" .. && \
+    make && \
+    make install && \
+    cd ../.. && \
+    rm -rf doxygen
+
+# INSTALL pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/3.1.11/pandoc-3.1.11-linux-amd64.tar.gz && \
+    tar -xvf pandoc-3.1.11-linux-amd64.tar.gz && \
+    cp -r pandoc-3.1.11/bin/* /usr/local/bin/ && \
+    rm -rf pandoc-3.1.11*
+
+# INSTALL full TeX Live from official installer (approx. 2GB installed)
+RUN dnf -y install perl wget tar && \
+    wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz && \
+    tar -xvzf install-tl-unx.tar.gz && \
+    rm install-tl-unx.tar.gz && \
+    cd install-tl-* && \
+    echo "selected_scheme scheme-full" > texlive.profile && \
+    ./install-tl -profile texlive.profile && \
+    ln -s /usr/local/texlive/2024/bin/x86_64-linux/* /usr/local/bin/ && \
+    cd .. && \
+    rm -rf install-tl-*
+
+# INSTALL recent R
+RUN wget https://cran.r-project.org/src/base/R-4/R-4.5.1.tar.gz && \
+    tar -xvf R-4.5.1.tar.gz && \
+    cd R-4.5.1 && \
+    ./configure --with-readline=no --without-x --with-cairo --with-pcre1 --enable-R-shlib && \
+    make && \
+    make install && \
+    Rscript -e "install.packages (c('knitr', 'rmarkdown', 'roxygen2'), repos='https://cloud.r-project.org/', dependencies = TRUE)" && \
+    cd .. && \
+    rm -rf R-4.5.1*
+
+# INSTALL SWIG
+RUN pipx uninstall swig && \
+    git clone https://github.com/fabien-ors/swig && \
+    cd swig && \
+    cmake -Bbuild && \
+    cd build && \
+    make && \
+    make install && \
+    cd ../.. && \
+    rm -rf swig


### PR DESCRIPTION
This PR introduces a new Dockerfile based on `manylinux_2_28_x86_64`. It should be a copy of the `almalinux-8` image but with more up-to-date C/C++ tooling.

Pierre